### PR TITLE
Feat: Setting messageIds via 'AddUserMessageActionResponse'

### DIFF
--- a/lexio/lib/state/rag-state.ts
+++ b/lexio/lib/state/rag-state.ts
@@ -10,7 +10,7 @@ const allowedActionReturnValues: Record<UserAction['type'], string[]> = {
     SEARCH_SOURCES: ['sources', 'followUpAction'],
     CLEAR_SOURCES: ['followUpAction'],
     SET_ACTIVE_SOURCES: ['followUpAction'],
-    SET_SELECTED_SOURCE: ['sourceData', 'followUpAction'],
+    SET_SELECTED_SOURCE: ['sourceData', 'citations', 'followUpAction'],
     SET_FILTER_SOURCES: ['followUpAction'],
     RESET_FILTER_SOURCES: ['followUpAction'],
     SET_MESSAGE_FEEDBACK: ['followUpAction']

--- a/lexio/lib/state/rag-state.ts
+++ b/lexio/lib/state/rag-state.ts
@@ -208,7 +208,7 @@ export const addUserMessageAtom = atom(
         const config = get(configAtom);
         const abortController = new AbortController();
 
-        // todo: new
+        // Initialize a new UUID for the user and assistant messages.
         let userMessageId = crypto.randomUUID() as UUID;
         let assistantMessageId = crypto.randomUUID() as UUID;
 
@@ -423,6 +423,7 @@ export const addUserMessageAtom = atom(
             }
 
             // todo: potentially wrap with addTimeout -> analogous to processCitations
+            // set the user message id in the completed messages to the awaited value
             if (response.setUserMessageId) {
                 const userMessageIdResolved = await response.setUserMessageId
 
@@ -435,7 +436,8 @@ export const addUserMessageAtom = atom(
                     return message;
                 }));
             }
-            // todo;
+            // todo: potentially wrap with addTimeout -> analogous to processCitations
+            // set the assistant message id in the completed messages to the awaited value
             if (response.setAssistantMessageId) {
                 const assistantMessageIdResolved = await response.setAssistantMessageId
                 const currentMessages = get(_completedMessagesAtom);

--- a/lexio/lib/state/rag-state.ts
+++ b/lexio/lib/state/rag-state.ts
@@ -1016,21 +1016,12 @@ export const dispatchAtom = atom(
             }
 
             // // ---- Process any follow-up action (recursive)
-            // if (payload && payload.followUpAction) {
-            //     promises.push(Promise.resolve(set(dispatchAtom, payload.followUpAction, true)));
-            // }
-            //
-            // // ---- Wait for all writes
-            // await Promise.all(promises);
-
-           // First, wait for all state updates to complete
-            await Promise.all(promises);
-
-            // Process follow-up action sequentially after all state updates are done
             if (payload && payload.followUpAction) {
-                await (dispatchAtom.write as any)(get, set, payload.followUpAction, true);
+                promises.push(Promise.resolve((dispatchAtom.write as any)(get, set, payload.followUpAction, true)));
             }
 
+            // ---- Wait for all writes
+            await Promise.all(promises);
 
         } catch (error) {
             console.error("Error in dispatch async writes:", error);

--- a/lexio/lib/types.ts
+++ b/lexio/lib/types.ts
@@ -399,6 +399,8 @@ export type UserAction =
  * @property {Promise<Source[]>} [sources] - Sources related to the message. These will be displayed in the SourcesDisplay component.
  * @property {Promise<Citation[]>} [citations] - Citations related to the message. These will be displayed in the SourcesDisplay component.
  * @property {string} [setUserMessage] - Updated user message. Can be used to modify the user's message before it's added to the chat.
+ * @property {string} [setUserMessageId] - ID of the user message. Can be used to modify the message ID before it's added to the chat.
+ * @property {string} [setAssistantMessageId] - ID of the assistant message. Can be used to modify the message ID before it's added to the chat.
  * @property {UserAction} [followUpAction] - Optional action to trigger after this one completes. Useful for chaining actions.
  */
 export interface AddUserMessageActionResponse {
@@ -406,6 +408,8 @@ export interface AddUserMessageActionResponse {
   sources?: Promise<Omit<Source, 'id'>[] | Source[]>; // id is generated here
   citations?: Promise<Citation[] | Omit<Citation, 'id'>[]>;
   setUserMessage?: string;
+  setUserMessageId?: Promise<UUID>;  // todo: new
+  setAssistantMessageId?: Promise<UUID>;  // todo: new
   followUpAction?: UserAction;
 }
 

--- a/lexio/lib/types.ts
+++ b/lexio/lib/types.ts
@@ -319,7 +319,8 @@ export type SetActiveSourcesAction = {
  * 
  * @property {string} type - The action type identifier
  * @property {string} sourceId - ID of the source to select
- * @property {Source} [sourceObject] - Optional source object to use
+ * @property {Source} [sourceObject] - Optional source object to use  
+ * @property {number} [pdfPageOverride] - Optional page number to display for PDF sources
  * @property {Component} source - The component that triggered the action
  */
 export type SetSelectedSourceAction = {
@@ -399,8 +400,8 @@ export type UserAction =
  * @property {Promise<Source[]>} [sources] - Sources related to the message. These will be displayed in the SourcesDisplay component.
  * @property {Promise<Citation[]>} [citations] - Citations related to the message. These will be displayed in the SourcesDisplay component.
  * @property {string} [setUserMessage] - Updated user message. Can be used to modify the user's message before it's added to the chat.
- * @property {string} [setUserMessageId] - ID of the user message. Can be used to modify the message ID before it's added to the chat.
- * @property {string} [setAssistantMessageId] - ID of the assistant message (response). Can be used to modify the message ID before it's added to the chat.
+ * @property {Promise<UUID>} [setUserMessageId] - ID of the user message. Can be used to modify the message ID before it's added to the chat.
+ * @property {Promise<UUID>} [setAssistantMessageId] - ID of the assistant message (response). Can be used to modify the message ID before it's added to the chat.
  * @property {UserAction} [followUpAction] - Optional action to trigger after this one completes. Useful for chaining actions.
  */
 export interface AddUserMessageActionResponse {
@@ -476,6 +477,7 @@ export interface SetActiveSourcesActionResponse {
  * @interface SetSelectedSourceActionResponse
  * @property {string | null} [selectedSourceId] - ID of the selected source. Set to null to deselect.
  * @property {Promise<string | Uint8Array>} [sourceData] - Data for the selected source. This will be displayed in the ContentDisplay component.
+ * @property {Promise<Citation[] | Omit<Citation, 'id'>[]>} [citations] - Citations related to the selected source. These will be displayed in the SourcesDisplay component.
  * @property {UserAction} [followUpAction] - Optional action to trigger after this one completes
  */
 export interface SetSelectedSourceActionResponse {

--- a/lexio/lib/types.ts
+++ b/lexio/lib/types.ts
@@ -400,7 +400,7 @@ export type UserAction =
  * @property {Promise<Citation[]>} [citations] - Citations related to the message. These will be displayed in the SourcesDisplay component.
  * @property {string} [setUserMessage] - Updated user message. Can be used to modify the user's message before it's added to the chat.
  * @property {string} [setUserMessageId] - ID of the user message. Can be used to modify the message ID before it's added to the chat.
- * @property {string} [setAssistantMessageId] - ID of the assistant message. Can be used to modify the message ID before it's added to the chat.
+ * @property {string} [setAssistantMessageId] - ID of the assistant message (response). Can be used to modify the message ID before it's added to the chat.
  * @property {UserAction} [followUpAction] - Optional action to trigger after this one completes. Useful for chaining actions.
  */
 export interface AddUserMessageActionResponse {
@@ -408,8 +408,8 @@ export interface AddUserMessageActionResponse {
   sources?: Promise<Omit<Source, 'id'>[] | Source[]>; // id is generated here
   citations?: Promise<Citation[] | Omit<Citation, 'id'>[]>;
   setUserMessage?: string;
-  setUserMessageId?: Promise<UUID>;  // todo: new
-  setAssistantMessageId?: Promise<UUID>;  // todo: new
+  setUserMessageId?: Promise<UUID>;
+  setAssistantMessageId?: Promise<UUID>;
   followUpAction?: UserAction;
 }
 

--- a/lexio/src/App.tsx
+++ b/lexio/src/App.tsx
@@ -160,10 +160,11 @@ function App() {
         response: Promise.resolve(MOCKED_RESPONSE.answer),
         sources: Promise.resolve(MOCKED_SOURCES),
         citations: Promise.resolve([]), // Empty citations - they'll be generated when source is selected
-        setUserMessageId: Promise.resolve("x-x-x-x-x-x"),  // test setting id
+        setUserMessageId: new Promise(resolve => setTimeout(() => resolve("ran-u-3s-x-x-" + Math.random().toString(36).substring(2, 15)), 500)),  // test setting id with 500ms delay
+        setAssistantMessageId: new Promise(resolve => setTimeout(() => resolve("ran-a-3s-x-x-" + Math.random().toString(36).substring(2, 15)), 1000)),  // test setting id with 500ms delay
         followUpAction: {
           type: 'SET_ACTIVE_MESSAGE',
-            messageId: 'x-x-x-x-x-x',
+            messageId: 'random-x-x-x-x-' + Math.random().toString(36).substring(2, 15),
         }
       };
     }

--- a/lexio/src/App.tsx
+++ b/lexio/src/App.tsx
@@ -73,6 +73,8 @@ function App() {
     _selectedSource: Source | null
   ): Promise<ActionHandlerResponse> => {
 
+    console.log(messages)
+
     if (action.type === 'SET_SELECTED_SOURCE') {
       if (!action.sourceObject) {
         return {};
@@ -158,6 +160,7 @@ function App() {
         response: Promise.resolve(MOCKED_RESPONSE.answer),
         sources: Promise.resolve(MOCKED_SOURCES),
         citations: Promise.resolve([]), // Empty citations - they'll be generated when source is selected
+        setUserMessageId: Promise.resolve("x-x-x-x-x-x"),
       };
     }
 

--- a/lexio/src/App.tsx
+++ b/lexio/src/App.tsx
@@ -160,8 +160,19 @@ function App() {
         response: Promise.resolve(MOCKED_RESPONSE.answer),
         sources: Promise.resolve(MOCKED_SOURCES),
         citations: Promise.resolve([]), // Empty citations - they'll be generated when source is selected
-        setUserMessageId: Promise.resolve("x-x-x-x-x-x"),
+        setUserMessageId: Promise.resolve("x-x-x-x-x-x"),  // test setting id
+        followUpAction: {
+          type: 'SET_ACTIVE_MESSAGE',
+            messageId: 'x-x-x-x-x-x',
+        }
       };
+    }
+
+    if (action.type === 'SET_ACTIVE_MESSAGE') {
+      console.log('SET_ACTIVE_MESSAGE action started');
+
+      // this is only for testing of the followUp action call
+      return {};
     }
 
   }, [contentSource, lastProcessedMessageId]);

--- a/lexio/src/stories/basic_usage/01_action_handler_pattern.stories.tsx
+++ b/lexio/src/stories/basic_usage/01_action_handler_pattern.stories.tsx
@@ -180,8 +180,8 @@ Each action type has specific return values defined in the \`allowedActionReturn
 
 \`\`\`typescript
 const allowedActionReturnValues: Record<UserAction['type'], string[]> = {
-    ADD_USER_MESSAGE: ['response', 'sources', 'setUserMessage', 'followUpAction'],
-    SET_ACTIVE_MESSAGE: ['followUpAction'],
+    ADD_USER_MESSAGE: ['response', 'sources', 'setUserMessage', 'setUserMessageId', 'setAssistantMessageId', 'followUpAction'],
+    SET_ACTIVE_MESSAGE: ['messageId', 'followUpAction'],
     CLEAR_MESSAGES: ['followUpAction'],
     SEARCH_SOURCES: ['sources', 'followUpAction'],
     CLEAR_SOURCES: ['followUpAction'],


### PR DESCRIPTION
## Added
- Added functionality to set the user and assistant message ids for chat messages via the 'AddUserMessageActionResponse' 
- Allowed Promise<UUID> as IDs

## Fixed
- Fixed a bug where followUpActions specified via the ActionHandlerResponse were not triggered.
